### PR TITLE
Fix HTML output for Python 3 compatibility.

### DIFF
--- a/diff_py/diff_helper.py
+++ b/diff_py/diff_helper.py
@@ -1,3 +1,4 @@
+import io
 import os
 import codecs
 import difflib
@@ -212,11 +213,11 @@ class HTMLDiffHelper(BaseDiffHelper):
         return self.report
 
     def make_report(self):
-        if isinstance(self.html_file, file):
-            self.html_file.write(self.report.unicode(indent=2).encode('utf8'))
+        if isinstance(self.html_file, io.IOBase):
+            self.html_file.write(str(self.report))
         else:
             with open(self.html_file, 'w') as f:
-                f.write(self.report.unicode(indent=2).encode('utf8'))
+                f.write(str(self.report))
 
 
 class ConsoleDiffHelper(BaseDiffHelper):


### PR DESCRIPTION
Hi! I installed your package from PyPI and had some difficulty using it with Python 3. I have updated a few lines that should fix this feature's compatibility with Python 3.

In my understanding, there is a `file` built-in type in Python 2 but not Python 3. I used [this approach](https://stackoverflow.com/questions/22958866/how-can-i-check-if-an-object-is-a-file-with-isinstance) to detect file-like objects. I also replaced the unicode string encoding since that step also breaks Python 3 compatibility.

This pull request _will_ break compatibility with Python 2, which reaches end-of-life in... 8 days. https://pythonclock.org/

Hope that is helpful!